### PR TITLE
add leading space to report of bucket creation

### DIFF
--- a/s3_credentials/cli.py
+++ b/s3_credentials/cli.py
@@ -291,7 +291,7 @@ def create(
                     s3.create_bucket(Bucket=bucket, **kwargs)
                     info = "Created bucket: {}".format(bucket)
                     if bucket_region:
-                        info += "in region: {}".format(bucket_region)
+                        info += " in region: {}".format(bucket_region)
                     log(info)
                     if bucket_policy:
                         s3.put_bucket_policy(


### PR DESCRIPTION
`Created bucket:my-bucket-namein region: eu-west-1` -> `Created bucket: my-bucket-name in region: eu-west-1`